### PR TITLE
Add support for boolean objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@
 	* @returns {Boolean} boolean indicating whether value is a boolean
 	*/
 	function isBoolean( value ) {
-		return ( typeof value === 'boolean' );
+		return ( typeof value === 'boolean' || Object.prototype.toString.call( value ) === '[object Boolean]' );
 	} // end FUNCTION isBoolean()
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,7 @@ describe( 'validate.io-boolean', function tests() {
 
 	it( 'should positively validate', function test() {
 		assert.ok( isBoolean( false ) );
+		assert.ok( isBoolean( new Boolean() ) );
 	});
 
 	it( 'should negatively validate', function test() {


### PR DESCRIPTION
Objects created with the `Boolean()` constructor report their type as `object`, not `boolean`. This adds a check for those kinds of objects.
